### PR TITLE
set strip_prefix to be empty

### DIFF
--- a/.bcr/source.template.json
+++ b/.bcr/source.template.json
@@ -1,5 +1,5 @@
 {
   "integrity": "",
-  "strip_prefix": "rules_platform-0.1.0",
+  "strip_prefix": "",
   "url": "https://github.com/bazelbuild/rules_platform/releases/download/0.1.0/rules_platform-0.1.0.tar.gz"
 }


### PR DESCRIPTION
 set strip_prefix to be empty as we do not rely on Github generated source archives and dont have a prefix to strip https://github.com/bazel-contrib/publish-to-bcr/tree/main/templates