### PR TITLE
Allow `platform_data` to also transition generated files.

### DIFF
--- a/platform_data/defs.bzl
+++ b/platform_data/defs.bzl
@@ -34,7 +34,7 @@ py_binary(
 )
 
 Regardless of what platform the top-level :flasher binary is built for,
-the :foo_embedded target will be built for //my/new:platform. 
+the :foo_embedded target will be built for //my/new:platform.
 
 Note that if you depend on :foo_embedded it's not exactly the same as depending on :foo, since it won't forward all the same providers. In the future, we can extend this to add some common providers as needed."""
 
@@ -71,11 +71,11 @@ def _platform_data_impl(ctx):
     runfiles = runfiles.merge(ctx.runfiles([new_executable]))
 
     return [
-	DefaultInfo(
+        DefaultInfo(
             files = files,
             runfiles = runfiles,
             executable = new_executable,
-	)
+        ),
     ]
 
 platform_data = rule(

--- a/platform_data/defs.bzl
+++ b/platform_data/defs.bzl
@@ -82,7 +82,7 @@ platform_data = rule(
     implementation = _platform_data_impl,
     attrs = {
         "target": attr.label(
-            allow_files = Truee,
+            allow_files = True,
             executable = True,
             mandatory = True,
             cfg = _target_platform_transition,

--- a/platform_data/defs.bzl
+++ b/platform_data/defs.bzl
@@ -82,7 +82,7 @@ platform_data = rule(
     implementation = _platform_data_impl,
     attrs = {
         "target": attr.label(
-            allow_files = False,
+            allow_files = Truee,
             executable = True,
             mandatory = True,
             cfg = _target_platform_transition,


### PR DESCRIPTION
The `allows_files` attribute controls both source and generated files, and so
needs to be set to true to allow `platform_data` to work correctly with
`genrule` and other custom rules.